### PR TITLE
Worflow-added-to-check-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,52 @@
+name: Lint Terraform
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - production
+      - staging
+  pull_request:
+    branches:
+      - main
+      - master
+      - production
+      - staging
+
+jobs:
+  terraform-lint:
+    name: Terraform Lint
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.5.0"
+
+      - name: Terraform Format Check
+        run: terraform fmt -check -recursive
+        
+      - name: Terraform Init
+        run: terraform init -backend=false
+        
+      - name: Terraform Validate
+        run: terraform validate
+
+      - name: Run TFLint
+        uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: v0.50.0
+          
+      - name: Show TFLint version
+        run: tflint --version
+        
+      - name: Init TFLint
+        run: tflint --init
+        
+      - name: Run TFLint
+        run: tflint -f compact

--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,4 @@ Thumbs.db
 .env.*.local
 
 # Ignore lock files (uncomment if you don't want to commit lock files)
-# .terraform.lock.hcl
+.terraform.lock.hcl


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to lint Terraform files. The workflow ensures that Terraform code adheres to formatting, initialization, validation, and linting standards.

### New GitHub Actions Workflow for Terraform Linting:

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R1-R52): Added a workflow named "Lint Terraform" triggered on `push` and `pull_request` events for specific branches (`main`, `master`, `production`, `staging`). The workflow includes steps for checking Terraform formatting (`terraform fmt`), initializing Terraform (`terraform init`), validating Terraform files (`terraform validate`), and running TFLint for linting (`tflint`).